### PR TITLE
use relative path on require_once

### DIFF
--- a/_admin/class.TicketAdminPage.php
+++ b/_admin/class.TicketAdminPage.php
@@ -1,5 +1,4 @@
 <?php
-require_once('class.SecurePage.php');
 require_once('class.FlipSession.php');
 require_once('app/TicketAutoload.php');
 class TicketAdminPage extends FlipAdminPage
@@ -27,7 +26,7 @@ class TicketAdminPage extends FlipAdminPage
              }
              else
              {
-                 $this->addNotification('The ticket system is operating in test mode. Any entries made will be deleted before ticketing starts.', 
+                 $this->addNotification('The ticket system is operating in test mode. Any entries made will be deleted before ticketing starts.',
                                         self::NOTIFICATION_WARNING);
              }
         }

--- a/class.TicketPage.php
+++ b/class.TicketPage.php
@@ -1,5 +1,5 @@
 <?php
-require_once('class.SecurePage.php');
+require_once('../class.SecurePage.php');
 require_once('class.FlipSession.php');
 require_once('app/TicketAutoload.php');
 class TicketPage extends SecurePage


### PR DESCRIPTION
adding to paths allows us to not rely on .htaccess files to set include_path