### PR TITLE
Remove name change from transfer page

### DIFF
--- a/js/transfer.js
+++ b/js/transfer.js
@@ -1,6 +1,7 @@
-function change_name_done(data)
+function change_name_done(jqXHR)
 {
-    if(data.error !== undefined)
+    var data = jqXHR.responseJSON;
+    if(data !== undefined && data.error !== undefined)
     {
         alert(data.error);
         return;
@@ -22,20 +23,6 @@ function transfer_done(data)
     {
         window.location = '/tickets/index.php?show_transfer_info=1';
     }
-}
-
-function change_name()
-{
-    var obj = {};
-    obj.firstName = $('#firstName').val();
-    obj.lastName  = $('#lastName').val();
-    $.ajax({
-        url: 'api/v1/tickets/'+encodeURIComponent($('#hash').val()),
-        type: 'patch',
-        data: JSON.stringify(obj),
-        processData: false,
-        dataType: 'json',
-        success: change_name_done});
 }
 
 function transfer()
@@ -62,7 +49,7 @@ function claim_ticket()
         data: JSON.stringify(obj),
         processData: false,
         dataType: 'json',
-        success: change_name_done});
+        complete: change_name_done});
 }
 
 function init_page()

--- a/transfer.php
+++ b/transfer.php
@@ -54,22 +54,6 @@ else
                 $page->body .= '<div id="content">
                                     <input class="form-control" type="hidden" name="hash" id="hash" value="'.$hash.'"/>
                                     <formset>
-                                        <legend>Change Name</legend>
-                                        <div class="form-group">
-                                            <label for="firstName" class="col-sm-2 control-label">First Name:</label>
-                                            <div class="col-sm-10">
-                                                <input class="form-control" type="text" name="firstName" id="firstName" data-toggle="tooltip" data-placement="top" title="The first name that matches the legal photo ID that will be presented at the Burning Flipside gate." value="'.$ticket->firstName.'"/>
-                                            </div>
-                                        </div>
-                                        <div class="form-group">
-                                            <label for="lastName" class="col-sm-2 control-label">Last Name:</label>
-                                            <div class="col-sm-10">
-                                                <input class="form-control" type="text" name="lastName" id="lastName" data-toggle="tooltip" data-placement="top" title="The last name that matches the legal photo ID that will be presented at the Burning Flipside gate." value="'.$ticket->lastName.'"/>
-                                            </div>
-                                        </div>
-                                        <button type="button" class="btn btn-primary" onclick="change_name()">Change Name</button>
-                                    </formset>
-                                    <formset>
                                         <legend>Change Ownership</legend>
                                         <div class="form-group">
                                             <label for="email" class="col-sm-2 control-label">Email:</label>


### PR DESCRIPTION
At the ticket lead's suggestion the transfer page will only have the transfer function. The edit button on the main page will still let a user change the ticket's name. 

Apparently having both options on this one page caused confusion. 